### PR TITLE
update recaptcha iframe src

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
+# 1.0.2
+
+## Bug Fixes
+
+### Fix hiding Google's reCAPTCHA overlay
+Modify reCAPTCHA's selector to fix auto-adjust z-index after its appearance
+
 # 1.0.1
 
-## Make sure we're not hiding recaptcha's pedestrain crossing recogniser
+## Bug Fixes
+
+### Make sure we're not hiding recaptcha's pedestrain crossing recogniser
 In case an element already existed on the page with z-index 2000000000 (which is Google's reCAPTCHA z-index), our modal was showing over it. This observer looks for Google's reCAPTCHA overlay and moves our modal **below** it.

--- a/lib/UIElements/index.js
+++ b/lib/UIElements/index.js
@@ -104,7 +104,7 @@ module.exports.createModal = function createModal({
                 ({ target }) => {
 
                     // Find div containing Google reCAPTCHA iframe
-                    if (target.querySelector('iframe[src*="google"][src*="recaptcha"]')) {
+                    if (target.querySelector('iframe[src*="recaptcha"]')) {
                         const recaptchaZIndex = Number(window.getComputedStyle(target).getPropertyValue('z-index'));
 
                         if (recaptchaZIndex && recaptchaZIndex <= zIndex) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "perimeterx-axios-interceptor",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "🧱 Intercept requests which are blocked by PerimeterX - pop up the challenge and retry the request",
   "keywords": [
     "perimeterx",


### PR DESCRIPTION
The challenge screen updates its z-index according to ReCaptcha z-index. Since the iframe has moved to a different domain (google.com/recaptcha -> recaptcha.net), this process was overlooked and z-index remained the highest on-page z-index (also dynamic).

[FIX]: Update iframe query to be broader

![image](https://user-images.githubusercontent.com/516342/116004655-9fb8e100-a5fb-11eb-9c4a-e54418651372.png)


| Before | After
| - | -
| ![](https://user-images.githubusercontent.com/516342/116004670-ad6e6680-a5fb-11eb-862b-10574f04c1a7.png) | ![](https://user-images.githubusercontent.com/516342/116004672-afd0c080-a5fb-11eb-8121-53626b92d46c.png)


