### PR TITLE
[FIX] (onerror report) for 403 responses with no data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.0.5
+
+## Improvements
+Fix (onerror report) for 403 responses with no data
+
 # 1.0.4
 
 ## Improvements

--- a/lib/isPXResponse/index.js
+++ b/lib/isPXResponse/index.js
@@ -4,7 +4,8 @@
 const REQUIRED_INFORMATION = ['appId', 'jsClientSrc', 'blockScript'];
 
 /**
- * @param {object} [data] Response object
+ * Check whether the response is a PX response block response, equiped with information to display exoneration modal
+ * @param {object} [data] Pasred response body
  * @returns {boolean}
  */
 module.exports = function isPXResponse(data) {

--- a/lib/isPXResponse/index.js
+++ b/lib/isPXResponse/index.js
@@ -4,10 +4,13 @@
 const REQUIRED_INFORMATION = ['appId', 'jsClientSrc', 'blockScript'];
 
 /**
- * @param {object} [data={}] Response object
+ * @param {object} [data] Response object
  * @returns {boolean}
  */
-module.exports = function isPXResponse(data = {}) {
+module.exports = function isPXResponse(data) {
+    if (!data) {
+        return false;
+    }
     const props = Object.getOwnPropertyNames(data);
 
     return REQUIRED_INFORMATION.every(

--- a/lib/rejected/spec.js
+++ b/lib/rejected/spec.js
@@ -77,9 +77,6 @@ describe('lib/rejected', () => {
             response: {
                 status: 403,
                 data: null
-            },
-            config: {
-                url: 'https://website.net'
             }
         };
         const rejected = require('.').bind(

--- a/lib/rejected/spec.js
+++ b/lib/rejected/spec.js
@@ -70,6 +70,29 @@ describe('lib/rejected', () => {
         resolver();
         await wait();
     });
+    it('should break immediately is error body is empty', async() => {
+        context.onerror = jest.fn();
+        expect.assertions(2);
+        const emptyError = {
+            response: {
+                status: 403,
+                data: null
+            },
+            config: {
+                url: 'https://website.net'
+            }
+        };
+        const rejected = require('.').bind(
+            Object.assign({}, context)
+        );
+
+        Promise.reject(emptyError).catch(rejected).catch((error) => {
+            expect(context.onerror).not.toHaveBeenCalled();
+            expect(error).toBe(emptyError);
+        });
+        resolver();
+        await wait();
+    });
     it('should resolve eventually only after challenge was resolved', async() => {
         let called = false;
         Promise.reject(error).catch(rejected).then(() => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "perimeterx-axios-interceptor",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "🧱 Intercept requests which are blocked by PerimeterX - pop up the challenge and retry the request",
   "keywords": [
     "perimeterx",


### PR DESCRIPTION
Prevent error logs for
```
TypeError: Cannot convert undefined or null to object at Function.getOwnPropertyNames ( anonymous )
```

> This was not causing breakage to the application