### PR TITLE
Allow the modal to be unclosable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 1.1.0
+
+## New features
+
+- Expose the entire ABR response data to the onerror callback
+- Add the option to disable modal close on click outside
+
 # 1.0.5
 
 ## Improvements

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ attach(axios, {
             '2. Enable Javascript'
         ],
         suffix: 'Still having issues? Contact support at support@example.com',
-        timeout: 3000
+        timeout: 3000,
+        allowClose: false
     }
 });
 
@@ -207,6 +208,8 @@ This object allows configuration of the modal GUI:
     - **Default**: "If you're still having trouble accessing the site, please contact customer support."
 - timeout (`{number}`): Time, in milliseconds, to allow PerimeterX script to load before aborting
     - **Default**: 3000 (3 seconds)
+- allowClose (`{boolean}`): Allow users to close the modal
+    - **Default**: true
 
 > Setting "title", "subtitle", "quickfixes", or "suffix" to a falsy value (null, empty string...) will prevent them from being rendered to GUI.
 

--- a/lib/UIElements/index.js
+++ b/lib/UIElements/index.js
@@ -46,14 +46,15 @@ module.exports.createModal = function createModal({
     subtitle = SUBTITLE,
     quickfixes = QUICKFIXES,
     suffix = SUFFIX,
-    abort = () => null
+    abort = () => null,
+    allowClose = true
 } = {}) {
 
     // The dialog element is used as an overlay on the page
     const dialog = document.createElement('dialog');
     dialog.className = [MODAL_CLASSNAME, className].filter(Boolean).join(' ');
     dialog.setAttribute('open', 'open');
-    dialog.addEventListener(
+    allowClose && dialog.addEventListener(
         'click',
         ({ target }) => {
             if (target !== dialog) {

--- a/lib/rejected/index.js
+++ b/lib/rejected/index.js
@@ -30,10 +30,12 @@ module.exports = function rejected(error) {
                     reject(error);
                     return;
                 }
-                const filtered = filter({
-                    appId: data.appId,
-                    path: error.config && error.config.url
-                });
+
+                const filtered = filter(Object.assign(
+                    {},
+                    data,
+                    { path: error.config && error.config.url }
+                ));
                 if (!filtered) {
                     error.ignored = true;
                     onignore(error.config);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "perimeterx-axios-interceptor",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "description": "🧱 Intercept requests which are blocked by PerimeterX - pop up the challenge and retry the request",
   "keywords": [
     "perimeterx",

--- a/playground/src/scripts/config/index.js
+++ b/playground/src/scripts/config/index.js
@@ -7,7 +7,7 @@ export const config = {
     onignore: (request) => info('[onignore]', request.url),
     onsuccess: (request) => info('[onsuccess]', request.url),
     onfailure: (request, error) => mockRequests.replay() || info('[onfailure]', request.url, ':', error.message),
-    filter: ({ path }) => path !== '/pxignore',
+    filter: ({ path, ignore }) => ignore !== true && path !== '/pxignore',
     modalConfig: {}
 };
 
@@ -27,7 +27,8 @@ export function useCustomModal(boolean) {
                 '1. Disable adblocker',
                 '2. Enable Javascript'
             ],
-            suffix: 'Still having issues? Contact support at support@example.com'
+            suffix: 'Still having issues? Contact support at support@example.com',
+            allowClose: false
         }
         : {}
     ;

--- a/playground/src/scripts/mockRequests/index.js
+++ b/playground/src/scripts/mockRequests/index.js
@@ -9,6 +9,7 @@ const BLOCK_REQUEST_AND_EXONERATE = '/pxblock';
 const BLOCK_THRICE = '/pxblock3';
 const BLOCK_MULTIPLE_REQUESTS = Array(3).fill(BLOCK_THRICE);
 const BLOCK_BUT_IGNORE_THE_BLOCKAGE = '/pxignore';
+const IGNORE_ADVANCED_BLOCK_RESPONSE = '/pxignoreabr';
 
 /**
  * Endpoint descriptions {text, value}
@@ -20,7 +21,8 @@ export const endpoints = Object.entries({
     SIMPLE_FORBIDDEN,
     BLOCK_REQUEST_AND_EXONERATE,
     BLOCK_MULTIPLE_REQUESTS,
-    BLOCK_BUT_IGNORE_THE_BLOCKAGE
+    BLOCK_BUT_IGNORE_THE_BLOCKAGE,
+    IGNORE_ADVANCED_BLOCK_RESPONSE
 }).map(
     ([key, value]) => ({
         text: key.replace(/_/g, ' ').toLowerCase(),
@@ -53,6 +55,8 @@ export default function mockRequests(axios, appId = '') {
         response: 'Forbidden'
     });
     moxios.stubRequest(BLOCK_REQUEST_AND_EXONERATE, new PXResponse({ appId }));
+
+    moxios.stubRequest(IGNORE_ADVANCED_BLOCK_RESPONSE, new PXResponse({ appId, ignore: true }));
 
     moxios.stubRequest(BLOCK_THRICE, new PXResponse({ appId, failureCount: 3 }));
 

--- a/specHelpers/PXResponse/index.js
+++ b/specHelpers/PXResponse/index.js
@@ -13,10 +13,10 @@ module.exports = class PXResponse {
      * @param {string} [o.appId]
      * @param {number} [o.failureCount] Amount of times to block before success
      */
-    constructor({ appId = PX_APP_ID, failureCount = 1 } = {}) {
+    constructor({ appId = PX_APP_ID, failureCount = 1, ...rest } = {}) {
         this.iterations = -1;
         this.failureCount = failureCount;
-        this.blockResponse = PXResponse.blockResponse(appId);
+        this.blockResponse = PXResponse.blockResponse(appId, rest);
     }
 
     /**
@@ -31,7 +31,7 @@ module.exports = class PXResponse {
      * @param {string} [appId]
      * @returns {object}
      */
-    static blockResponse(appId = PX_APP_ID) {
+    static blockResponse(appId = PX_APP_ID, rest = {}) {
         return {
             appId,
             jsClientSrc: `https://client.perimeterx.net/${appId}/main.min.js`,
@@ -39,7 +39,8 @@ module.exports = class PXResponse {
             vid: '2b99ec08-3a22-49f0-a289-a4a6c330b059',
             uuid: '610a4a35-c45f-4cae-bc58-5abac3a4cdcd',
             hostUrl: 'https://www.website.net',
-            blockScript: `https://captcha.px-cdn.net/${appId}/captcha.js`
+            blockScript: `https://captcha.px-cdn.net/${appId}/captcha.js`,
+            ...rest
         };
     }
 


### PR DESCRIPTION
1. Expose the entire ABR response data to the onerror callback
1. Add the option to disable modal close on click outside