### PR TITLE
Add "compact" mode to modal config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.2.0
+
+- Add "compact" mode to modal configuration to reduce the size of the modal - helps to fit in tight spaces like iframes
+
 # 1.1.3
 
 ## Improvement

--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ attach(axios, {
         ],
         suffix: 'Still having issues? Contact support at support@example.com',
         timeout: 3000,
-        allowClose: false
+        allowClose: false,
+        compact: false,
     }
 });
 
@@ -213,6 +214,8 @@ This object allows configuration of the modal GUI:
     - **Default**: 3000 (3 seconds)
 - allowClose (`{boolean}`): Allow users to close the modal
     - **Default**: true
+= compact (`{boolean}`): Compact mode - modify some of the default CSS to reduce the size of the modal - helps to fit in tight spaces like iframes
+    - **Default**: false
 
 > Setting "title", "subtitle", "quickfixes", or "suffix" to a falsy value (null, empty string...) will prevent them from being rendered to GUI.
 

--- a/lib/UIElements/__snapshots__/spec.js.snap
+++ b/lib/UIElements/__snapshots__/spec.js.snap
@@ -47,6 +47,7 @@ exports[`lib/UIElements createModal should build the modal UI, PerimeterX and de
     padding: 0;
     background: rgba(0, 0, 0, .3);
     color: black;
+    
 }
 .perimeterx-async-challenge &gt; div {
     margin: 20vh 20vw 0;

--- a/lib/UIElements/index.js
+++ b/lib/UIElements/index.js
@@ -42,6 +42,7 @@ module.exports.removeCaptcha = function removeCaptcha() {
  */
 module.exports.createModal = function createModal({
     className = '',
+    compact = false,
     title = TITLE,
     subtitle = SUBTITLE,
     quickfixes = QUICKFIXES,
@@ -93,7 +94,7 @@ module.exports.createModal = function createModal({
     // Style element (CSS)
     const style = document.createElement('style');
     const zIndex = highestZIndex(9999);
-    style.textContent = styles({ zIndex });
+    style.textContent = styles({ compact, zIndex });
     wrap.appendChild(style);
 
     observer && observer.disconnect();

--- a/lib/UIElements/styles.js
+++ b/lib/UIElements/styles.js
@@ -32,7 +32,7 @@ const QUICKFIX_CLASSNAME = 'quickfix';
  * Style tag content
  * @type {string}
  */
-const styles = ({ zIndex = 10000 } = {}) => `
+const styles = ({ compact = false, zIndex = 10000 } = {}) => `
 .${MODAL_CLASSNAME} {
     z-index: ${zIndex};
     position: fixed;
@@ -45,9 +45,10 @@ const styles = ({ zIndex = 10000 } = {}) => `
     padding: 0;
     background: rgba(0, 0, 0, .3);
     color: black;
+    ${compact ? 'font-size: smaller;' : ''}
 }
 .${MODAL_CLASSNAME} > div {
-    margin: 20vh 20vw 0;
+    margin: ${compact ? '0' : '20vh 20vw 0'};
     background: white;
     box-shadow: 0 0 2em rgba(0, 0, 0, .4);
     padding: 1em 1.5em;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "perimeterx-axios-interceptor",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "🧱 Intercept requests which are blocked by PerimeterX - pop up the challenge and retry the request",
   "keywords": [
     "perimeterx",
@@ -13,7 +13,7 @@
     "bot",
     "🤖"
   ],
-  "author": "Fiverr SRE",
+  "author": "Fiverr Team",
   "license": "MIT",
   "homepage": "https://fiverr.github.io/perimeterx-axios-interceptor/",
   "repository": {


### PR DESCRIPTION
CSS modifications to help reduce overall size by reducing font size and outer margin.
The rest can be done using existing configurations (remove elements, change texts, etc)

![](https://github.com/user-attachments/assets/6d7ce415-07c5-4ece-ae1f-db25e3c8f0cc)
